### PR TITLE
Initial version of the two-tier docker compose.

### DIFF
--- a/ConnectAll
+++ b/ConnectAll
@@ -1,0 +1,37 @@
+#install4j response file for ConnectAll 2.8.3.R67dc0c2b
+#Sun Jul 15 15:27:26 UTC 2018
+sys.installationDir=/ConnectAll
+jdbc.user=root
+dbname=mysql
+sys.languageId=en
+sys.component.262$Boolean=true
+jdbc.url=sql
+javaHome=/usr/local/bin/java1.7
+javaVersion$Integer=0
+uiShutdownPort=8005
+# mule
+sys.component.5397$Boolean=false
+#tomcat
+sys.component.203$Boolean=true
+# java
+sys.component.11552$Boolean=true
+upgradeOption$Integer=0
+DbType$Integer=2
+tomcatHome=/ConnectAll
+#/CATomcat
+sys.adminRights$Boolean=true
+
+# Ports available to the other docker nodes
+schedulerServicePort=9090
+configPort=8081
+activityMonitorPort=9080
+
+# The shared volume to store the application link jsons
+CONNECTALL_HOME=/connectall_home
+
+# Ports available outside docker
+pushServicePort=7070
+configGUIPort=8080
+genericRestServicePort=8090
+
+

--- a/connectall.docker
+++ b/connectall.docker
@@ -1,0 +1,18 @@
+FROM ubuntu:14.04
+RUN mkdir /ConnectAll
+WORKDIR /ConnectAll
+ADD connectall.varfile /ConnectAll/. 
+ARG INSTALLER
+ADD ${INSTALLER} /ConnectAll/ConnectAll.sh
+ADD install.sh /ConnectAll/.
+ADD start /ConnectAll/.
+ADD stop /ConnectAll/.
+ADD readme.html /ConnectAll/.
+ADD setup /ConnectAll/.
+ENV MULE_HOME=/ConnectAll/mulesoft/mule-standalone-3.6.1
+#ADD .profile /root/.profile
+ENV CONNECTALL_HOME=/ConnectAll/mulesoft/mule-standalone-3.6.1/database
+ENV CATALINA_HOME=/ConnectAll/CATomcat
+ENV JAVA_HOME=/usr/local/bin/java1.7/jdk1.7.0_79
+ENTRYPOINT ["/ConnectAll/install.sh","/ConnectAll/ConnectAll.sh","connectall.varfile","/bin/bash -c /ConnectAll/mulesoft/mule-standalone-3.6.1/bin/mule","tail -f /ConnectAll/mulesoft/mule-standalone-3.6.1/logs/mule.log"]
+#ENTRYPOINT ["tail","-f","/dev/null"]

--- a/connectall.varfile
+++ b/connectall.varfile
@@ -1,0 +1,36 @@
+#install4j response file for ConnectAll 2.8.3.R67dc0c2b
+#Sun Jul 15 15:27:26 UTC 2018
+sys.installationDir=/ConnectAll
+jdbc.user=root
+dbname=mysql
+sys.languageId=en
+sys.component.262$Boolean=true
+jdbc.url=sql
+javaHome=/usr/local/bin/java1.7
+javaVersion$Integer=0
+uiShutdownPort=8005
+# mule
+sys.component.5397$Boolean=true
+#tomcat
+sys.component.203$Boolean=true
+# java
+sys.component.11552$Boolean=true
+upgradeOption$Integer=0
+DbType$Integer=2
+tomcatHome=/ConnectAll/CATomcat
+sys.adminRights$Boolean=true
+
+# Ports available to the other docker nodes
+schedulerServicePort=9090
+configPort=8081
+activityMonitorPort=9080
+
+# The shared volume to store the application link jsons
+CONNECTALL_HOME=/ConnectAll/mulesoft/mule-standalone-3.6.1/database
+
+# Ports available outside docker
+pushServicePort=7070
+configGUIPort=8080
+genericRestServicePort=8090
+
+

--- a/connectall_mule.docker
+++ b/connectall_mule.docker
@@ -1,0 +1,15 @@
+FROM ubuntu:14.04
+RUN mkdir /ConnectAll
+WORKDIR /ConnectAll
+ADD connectall_mule.varfile /ConnectAll/. 
+ARG INSTALLER
+ADD ${INSTALLER} /ConnectAll/ConnectAll.sh
+ADD install.sh /ConnectAll/.
+ADD .profile /root/.profile
+ENV MULE_HOME=/ConnectAll/mulesoft/mule-standalone-3.6.1
+ENV CONNECTALL_HOME=/connectall_home
+ENV CATALINA_HOME=/ConnectAll/CATomcat
+ENV JAVA_HOME=/usr/local/bin/java1.7/jdk1.7.0_79
+#ENTRYPOINT ["/ConnectAll/mulesoft/mule-standalone-3.6.1/bin/mule"]
+ENTRYPOINT ["/ConnectAll/install.sh","/ConnectAll/ConnectAll.sh","connectall_mule.varfile","/ConnectAll/tomcat/bin/shutdown.sh","/usr/bin/tail -f /ConnectAll/mulesoft/mule-standalone-3.6.1/logs/mule.log"]]
+

--- a/connectall_mule.varfile
+++ b/connectall_mule.varfile
@@ -1,0 +1,36 @@
+#install4j response file for ConnectAll 2.8.3.R67dc0c2b
+#Sun Jul 15 15:27:26 UTC 2018
+sys.installationDir=/ConnectAll
+jdbc.user=root
+dbname=mysql
+sys.languageId=en
+sys.component.262$Boolean=true
+jdbc.url=sql
+javaHome=/usr/local/bin/java1.7
+javaVersion$Integer=0
+uiShutdownPort=8005
+# mule
+sys.component.5397$Boolean=true
+#tomcat
+sys.component.203$Boolean=true
+# java
+sys.component.11552$Boolean=true
+upgradeOption$Integer=0
+DbType$Integer=2
+tomcatHome=/ConnectAll/CATomcat
+sys.adminRights$Boolean=false
+
+# Ports available to the other docker nodes
+schedulerServicePort=9090
+configPort=8081
+activityMonitorPort=9080
+
+# The shared volume to store the application link jsons
+CONNECTALL_HOME=/connectall_home
+
+# Ports available outside docker
+pushServicePort=7070
+configGUIPort=8080
+genericRestServicePort=8090
+
+

--- a/connectall_ui.varfile
+++ b/connectall_ui.varfile
@@ -1,0 +1,36 @@
+#install4j response file for ConnectAll 2.8.3.R67dc0c2b
+#Sun Jul 15 15:27:26 UTC 2018
+sys.installationDir=/ConnectAll
+jdbc.user=root
+dbname=mysql
+sys.languageId=en
+sys.component.262$Boolean=true
+jdbc.url=sql
+javaHome=/usr/local/bin/java1.7
+javaVersion$Integer=0
+uiShutdownPort=8005
+# mule
+sys.component.5397$Boolean=false
+#tomcat
+sys.component.203$Boolean=true
+# java
+sys.component.11552$Boolean=true
+upgradeOption$Integer=0
+DbType$Integer=2
+tomcatHome=/ConnectAll/CATomcat
+sys.adminRights$Boolean=true
+
+# Ports available to the other docker nodes
+schedulerServicePort=9090
+configPort=8081
+activityMonitorPort=9080
+
+# The shared volume to store the application link jsons
+CONNECTALL_HOME=/connectall_home
+
+# Ports available outside docker
+pushServicePort=7070
+configGUIPort=8080
+genericRestServicePort=8090
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,28 @@
+version: '3'
+services:
+  sql:
+    image: "mysql:5.6"
+    environment:
+    - MYSQL_ALLOW_EMPTY_PASSWORD=1
+    labels:
+      - com.connectall.com.tier = database
+  app:
+    depends_on: 
+    - sql
+    labels:
+      - com.connectall.com.tier = app
+    build:
+      context: .
+      dockerfile: "connectall.docker"
+      args:
+        INSTALLER: ${INSTALLER:?The INSTALLER environment variable must include ConnectAll installer script filename}
+    image: connectall_app:${VERSION:?The VERSION environment variable must include the ConnectAll version eg 2.8.2}
+    ports:
+      - "7070:7070"
+      - "8090:8090"
+      - "80:8080"
+    volumes:
+      - ${CONNECTALL:-mule}:/ConnectAll/mulesoft
+
+volumes:
+  mule:

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+echo Sleeping while mounts are created
+sleep 60
+export JAVA_HOME=/usr/local/bin/java1.7/jdk1.7.0_79
+export PATH=$JAVA_HOME/bin:$PATH
+echo "Change to the /ConnectAll folder"
+cd /ConnectAll
+echo "Make all the script executable"
+chmod +x $1
+echo "Execute the installer $1 with the varfile $2"
+$1 -varfile $2 -q  -console   -Dinstall4j.keepLog=true   -Dinstall4j.logToStderr=true
+$3
+$4

--- a/readme.html
+++ b/readme.html
@@ -1,0 +1,9 @@
+<b>Welcome to the ConnectAll (tm) two tier docker installation.</b>
+
+The first time you bring up the container run the setup script.
+
+You can then stop and start the containers but please run the "stop" before shutting down and run the "start" script when starting up. This will start jp Mule and Tomcat.<br>
+
+Once running you can access the ConnectAll user interface at <a href="http://localhost/ConnectAll">ConnectAll</a><br>
+
+Enjoy, and submit any bug reports <a href="https://jira.connectall.com/servicedesk/customer/portal/11">here</s\a>.

--- a/setup
+++ b/setup
@@ -1,0 +1,1 @@
+/ConnectAll/install.sh /ConnectAll/ConnectAll.sh /ConnectAll/connectall.varfile

--- a/start
+++ b/start
@@ -1,0 +1,3 @@
+. ~/.profile
+$MULE_HOME/bin/mule start
+$CATALINA_HOME/bin/startup.sh

--- a/stop
+++ b/stop
@@ -1,0 +1,3 @@
+. ~/.profile
+$MULE_HOME/bin/mule start
+$CATALINA_HOME/bin/startup.sh

--- a/up
+++ b/up
@@ -1,0 +1,1 @@
+export INSTALLER=ConnectAll_Unix_2_8_3_R67dc0c2b_64.sh ; export VERSION=2.8.3.11; export CONNECTALL=./mule; docker-compose up


### PR DESCRIPTION
The easy way is to start this up is run the ./up script. You'll also notice in the yml file there are other variables you can set to use different external ports. 

Btw, this should run exactly like any other ConnectAll 2.8.3 install but a LOT easier to install (in one minute)! It has one node for MySql and another for ConnectAll (tomcat and mule).

Once its started successfully access the UI using your browser at http://localhost/ConnectAll. Please send an email to sales@orasi.com to get the need evaluation licenses.